### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
-            <version>1.5.0</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_2.10</artifactId>
-            <version>1.5.0</version>
+            <version>1.3.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The version used in the pom file is wrong. Following the documentation mention in http://hortonworks.com/hdp/whats-new/  the spark version is 1.3.1 and using diffrent version would lead a problem during the runtime, for example in the correct version the classifier https://spark.apache.org/docs/1.3.1/api/java/org/apache/spark/mllib/classification/NaiveBayes.html doesn't have a new model type like specifed here https://spark.apache.org/docs/1.5.0/api/java/org/apache/spark/mllib/classification/NaiveBayes.html , and if you try to set that type during the invocation o the train() method it would result a runtime exception.
